### PR TITLE
Move the build script to it's own file so it doesn't rely on ahoy to …

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -2,12 +2,7 @@ ahoyapi: v2
 commands:
   build:
     usage: Build ahoy with a version automatically set.
-    cmd: |
-      set -e
-      COMMIT=$(git rev-parse --short HEAD)
-      VERSION=$(git describe --tag $COMMIT)
-      go build -ldflags "-X main.version=$VERSION"
-      echo "Built ahoy version $VERSION"
+    cmd: bash build.sh {{args}}
   install:
     cmd: "go install"
     usage: Build ahoy using go install.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+set -e
+NAME='ahoy'
+COMMIT=$(git rev-parse --short HEAD)
+VERSION=$(git describe --tag $COMMIT)
+go build -ldflags "-X main.version=$VERSION" -o $NAME "$@"
+echo "Built ahoy version $VERSION"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 test:
   pre:
     - go get -u github.com/golang/lint/golint
-    - go build -v
+    - bash build.sh -v
   override:
     - ./ahoy test


### PR DESCRIPTION
…build. Update circleCI to build with a version number.